### PR TITLE
Automatically register tools with `pickaxe` group

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -2,15 +2,13 @@ modpath = minetest.get_modpath("pick_axe_tweaks")
 dofile(modpath .. "/api.lua")
 dofile(modpath .. "/chat_commands.lua")
 
-if minetest.get_modpath("default") then
-    local default_pick_axes = {
-        "default:pick_wood",
-        "default:pick_stone",
-        "default:pick_bronze",
-        "default:pick_steel",
-        "default:pick_mese",
-        "default:pick_diamond",
-    }
-
-    pick_axe_tweaks.register_pick_axes(default_pick_axes)
-end
+-- Register all tools with `pickaxe` group
+minetest.register_on_mods_loaded(function()
+	local pickaxes = {}
+	for name, def in pairs(minetest.registered_items) do
+		if def.type == "tool" and def.groups and def.groups.pickaxe then
+			table.insert(pickaxes, name)
+		end
+	end
+	pick_axe_tweaks.register_pick_axes(pickaxes)
+end)

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,2 @@
 name = pick_axe_tweaks
 description = adds the ability for pick axes to place light nodes on right click
-optional_depends = default


### PR DESCRIPTION
So that `pick_axe_tweaks` support doesn't have to be added to every mod that adds a pickaxe.